### PR TITLE
Fix rest parsing

### DIFF
--- a/pyabc.py
+++ b/pyabc.py
@@ -401,10 +401,10 @@ class InlineField(Token):
     pass
 
 class Rest(Token):
-    def __init__(self, char, num, denom, **kwds):
+    def __init__(self, symbol, num, denom, **kwds):
         # char==X or Z means length is in measures
         Token.__init__(self, **kwds)
-        self.char = char
+        self.symbol = symbol
         self.length = (num, denom)
             
 


### PR DESCRIPTION
Cant use parameter 'char' for Rest since this is used in Token. This causes TypeError: __init__() got multiple values for argument 'char'. (Might be a python3 thing). I renamed char parameter to something else. 