### PR TITLE
Fix parsing IndexError

### DIFF
--- a/pyabc.py
+++ b/pyabc.py
@@ -576,7 +576,7 @@ class Tune(object):
                     continue
 
                 # Broken rhythm
-                if isinstance(tokens[-1], (Note, Rest)):
+                if tokens and isinstance(tokens[-1], (Note, Rest)):
                     m = re.match('<+|>+', part)
                     if m is not None:
                         tokens.append(Dot(line=i, char=j, text=m.group()))


### PR DESCRIPTION
If content starts with an annotation (for example), IndexError was caused. I added a check that tokens length > 0 before trying to index into them.
