### PR TITLE
Support half length rest (z/)

### DIFF
--- a/pyabc.py
+++ b/pyabc.py
@@ -584,7 +584,7 @@ class Tune(object):
                         continue
 
                 # Rest
-                m = re.match('([XZxz])(\d+)?(/(\d+))?', part)
+                m = re.match('([XZxz])(\d+)?(/(\d+)?)?', part)
                 if m is not None:
                     g = m.groups()
                     tokens.append(Rest(g[0], num=g[1], denom=g[3], line=i, char=j, text=m.group()))


### PR DESCRIPTION
Similar to notes, the regex should allow for duration of only / i.e., "z/". The number following the slash needs to be optional.
