### PR TITLE
fix small issue recognising minor keys.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+tunes.json
+

--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Basic goals
 * Analyze tunes to determine the modes and keys they use
 * Automatically annotate tunes with chord names
 * From a library of tunes, suggest sets that fit together nicely
+
+
+Testing
+-------
+Limit unit testing has been implemented. To run unit tests
+```bash
+cd /your/pyabc/directory
+PYTHONPATH=$PYTHONPATH:$PWD pytest
+```

--- a/pyabc.py
+++ b/pyabc.py
@@ -139,6 +139,8 @@ class Key(object):
             acc = ''
         if mode is None:
             mode = 'major'
+        if mode is 'm':
+            mode = 'minor'
         try:
             mode = mode_abbrev[mode[:3].lower()]
         except KeyError:
@@ -431,7 +433,7 @@ class Newline(Token):
     pass
 
 class Continuation(Token):
-    """  \ at end of line  """
+    """  \\ at end of line  """
     pass
 
 class GracenoteBrace(Token):
@@ -779,6 +781,7 @@ if __name__ == '__main__':
         ticks = []
         for i in (0, 1):
             for pitch in "CDEFGAB":
+
                 ticks.append((i*12 + pitch_values[pitch], pitch))
 
         plt.getAxis('left').setTicks([ticks])

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,0 +1,42 @@
+"""
+Tests for the key signature class
+"""
+
+import pytest
+import itertools
+
+from pyabc import Key
+
+
+def every_possible_key():
+    """
+    Create a list of every possible key that a user might send to software
+    for use in testing.
+
+    returns:
+        A list of most of the more likely user inputs for key signature.
+
+    references:
+        http://abcnotation.com/wiki/abc:standard:v2.1#kkey
+    """
+    # Base List of Keys @TODO Need to add sharps and flats
+    keys = ['A','B', 'C', 'D', 'E', 'F', 'G', 'Bb', 'C#', 'Eb', 'F#', 'G#']
+
+    # List of Modes in Sentence case
+    modes = ['Ionian', 'Aeolian', 'Mixolydian', 'Dorian', 'Phrygian',
+     	    'Lydian', 'Locrian', 'Major', 'Minor']
+
+    # Append upper and lower case versions of the above
+    modes += [mode.lower() for mode in modes] +\
+             [mode.upper() for mode in modes]
+
+    # Append truncated versions of the above
+    modes += [mode[:3] for mode in modes] + ['m']
+
+    return [str(x[0] + x[1]) for x in itertools.product(keys, modes)]
+
+
+@pytest.mark.parametrize("key", every_possible_key())
+def test_parse_key_basic(key):
+    # Attempt to create key using key string provided.
+    Key(name=key)


### PR DESCRIPTION
> As a special case, minor may be abbreviated to m. 

http://abcnotation.com/wiki/abc:standard:v2.1#kkey

I couldn't get this working so I fixed it. The fix is small, but just as a sanity check I added a test, and instructions on how to run this test to README.md.