### PR TITLE
Makepyabc a module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 tunes.json
-
+pyabc.egg-info
+.abc
+.ABC

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Basic goals
 * From a library of tunes, suggest sets that fit together nicely
 
 
+Installation
+------------
+You can install pyabc as a module using
+```bash
+pip install -e /your/py/abc/directory
+```
+
 Testing
 -------
 Limit unit testing has been implemented. To run unit tests

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+"""A setuptools based setup module.
+See:
+https://packaging.python.org/guides/distributing-packages-using-setuptools/
+https://github.com/pypa/sampleproject
+"""
+
+
+from setuptools import setup, find_packages
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='pyabc',  # Required
+    version='1.0.0',  # Required
+    description='A Python Library for Parsing ABC files',
+    long_description=long_description,
+    long_description_content_type='text/markdown',  # Optional (see note above)
+    # @TODO url='https://github.com/pypa/sampleproject'
+    author='Campagnola',
+    python_requires='>3.6',
+    # @TODO install_requires=['peppercorn'],
+)


### PR DESCRIPTION
I've been using this with a separate programme of my own to create guitar tabs.
Recent work on packaging other projects made me realise that installing pyabc as a package might
be easier. If you don't like this feel free to ignore.